### PR TITLE
Don't add whitespace to sys/sysnb syscall function wrapper comments

### DIFF
--- a/internal/gofumpt.go
+++ b/internal/gofumpt.go
@@ -172,7 +172,8 @@ func (f *fumpter) printLength(node ast.Node) int {
 //   //someword:  | similar to the syntax above, like lint:ignore
 //   //line       | inserted line information for cmd/compile
 //   //export     | to mark cgo funcs for exporting
-var rxCommentDirective = regexp.MustCompile(`^([a-z]+:|line\b|export\b)`)
+//   //sys(nb)?   | syscall function wrapper prototypes
+var rxCommentDirective = regexp.MustCompile(`^([a-z]+:|line\b|export\b|sys(nb)?\b)`)
 
 func (f *fumpter) visit(node ast.Node) {
 	switch node := node.(type) {

--- a/testdata/scripts/comment-spaced.txt
+++ b/testdata/scripts/comment-spaced.txt
@@ -20,6 +20,10 @@ package p
 
 //line 123
 
+//sys   Unlink(path string) (err error)
+
+//sysnb	Getpid() (pid int)
+
 //foo is foo.
 type foo int
 
@@ -53,6 +57,10 @@ package p
 //export CgoFunc
 
 //line 123
+
+//sys   Unlink(path string) (err error)
+
+//sysnb	Getpid() (pid int)
 
 // foo is foo.
 type foo int


### PR DESCRIPTION
The syscall and golang.org/x/sys packages use //sys and //sysnb comments
to declare system call function wrapper prototypes. Those get read by
mksyscall.go to generate the actual syscall wrappers and it expects the
comments without a whitespace.