### PR TITLE
Don't add whitespace to //extern comments

### DIFF
--- a/internal/gofumpt.go
+++ b/internal/gofumpt.go
@@ -174,8 +174,9 @@ func (f *fumpter) printLength(node ast.Node) int {
 //   //someword:  | similar to the syntax above, like lint:ignore
 //   //line       | inserted line information for cmd/compile
 //   //export     | to mark cgo funcs for exporting
+//   //extern     | C function declarations for gccgo
 //   //sys(nb)?   | syscall function wrapper prototypes
-var rxCommentDirective = regexp.MustCompile(`^([a-z]+:|line\b|export\b|sys(nb)?\b)`)
+var rxCommentDirective = regexp.MustCompile(`^([a-z]+:|line\b|export\b|extern\b|sys(nb)?\b)`)
 
 // visit takes either an ast.Node or a []ast.Stmt.
 func (f *fumpter) applyPre(c *astutil.Cursor) {

--- a/testdata/scripts/comment-spaced.txt
+++ b/testdata/scripts/comment-spaced.txt
@@ -18,6 +18,9 @@ package p
 
 //export CgoFunc
 
+//extern open
+func c_open(name *byte, mode int, perm int) int
+
 //line 123
 
 //sys   Unlink(path string) (err error)
@@ -55,6 +58,9 @@ package p
 // TODO: do something
 
 //export CgoFunc
+
+//extern open
+func c_open(name *byte, mode int, perm int) int
 
 //line 123
 


### PR DESCRIPTION
When using gccgo, the //extern comment can be used to declare C
functions to call from Go, see
https://golang.org/doc/install/gccgo#Function_names

These comments shouldn't have a whitespace added.