### PR TITLE
Support a -format-only flag which same as goimports

### DIFF
--- a/gofumports/goimports.go
+++ b/gofumports/goimports.go
@@ -49,6 +49,7 @@ var (
 func init() {
 	flag.BoolVar(&options.AllErrors, "e", false, "report all errors (not just the first 10 on different lines)")
 	flag.StringVar(&imports.LocalPrefix, "local", "", "put imports beginning with this string after 3rd-party packages; comma-separated list")
+	flag.BoolVar(&options.FormatOnly, "format-only", false, "if true, don't fix imports and only format. In this mode, goimports is effectively gofmt, with the addition that imports are grouped into sections.")
 }
 
 func report(err error) {


### PR DESCRIPTION
Support a `-format-only` flag which same as `goimports`.

ref:
- https://golang.org/cl/174326
- golang/tools@9d4d845e86
