### PR TITLE
Ensure there is an empty line between std and other imports

### DIFF
--- a/internal/gofumpt.go
+++ b/internal/gofumpt.go
@@ -405,6 +405,10 @@ func (f *fumpter) joinStdImports(d *ast.GenDecl) {
 		}
 		std = append(std, spec)
 	}
+	// Ensure there is an empty line between std imports and other imports
+	if std != nil && other != nil && f.file.Line(std[len(std)-1].End()) + 1 == f.file.Line(other[0].Pos()) {
+		f.addNewline(other[0].Pos())
+	}
 	// Finally, join the imports, keeping std at the top.
 	d.Specs = append(std, other...)
 }

--- a/testdata/scripts/import-details.txt
+++ b/testdata/scripts/import-details.txt
@@ -1,0 +1,39 @@
+gofumpt -w foo.go .
+cmp foo.go foo.go.golden
+
+-- foo.go --
+package p
+
+import (
+	"golang.org/x/xerrors"
+
+	errors2 "github.com/pkg/errors"
+
+	"fmt"
+	"errors"
+)
+
+func Func() {
+	err := errors2.New("error")
+	err = errors.Wrap(err, "failure")
+	err = xerrors.Errorf("exception: %x", err)
+	fmt.Println(err.Error())
+}
+-- foo.go.golden --
+package p
+
+import (
+	"errors"
+	"fmt"
+
+	"golang.org/x/xerrors"
+
+	errors2 "github.com/pkg/errors"
+)
+
+func Func() {
+	err := errors2.New("error")
+	err = errors.Wrap(err, "failure")
+	err = xerrors.Errorf("exception: %x", err)
+	fmt.Println(err.Error())
+}


### PR DESCRIPTION
It should go from

```go
import (
	"golang.org/x/xerrors"

	errors2 "github.com/pkg/errors"

	"fmt"
	"errors"
)
```

to

```go
import (
	"errors"
	"fmt"

	"golang.org/x/xerrors"

	errors2 "github.com/pkg/errors"
)
```