### PR TITLE
strings.Trim expects a cutset, not a string

### DIFF
--- a/gofumports/internal/imports/fix.go
+++ b/gofumports/internal/imports/fix.go
@@ -377,7 +377,7 @@ func (p *pass) fix() bool {
 			if imp.Name != nil {
 				continue
 			}
-			path := strings.Trim(imp.Path.Value, `""`)
+			path := strings.Trim(imp.Path.Value, `"`)
 			ident := p.importIdentifier(&importInfo{importPath: path})
 			if ident != importPathToAssumedName(path) {
 				imp.Name = &ast.Ident{Name: ident, NamePos: imp.Pos()}


### PR DESCRIPTION
strings.Trim treats the second parameter as a set of characters you
want to trim. It does not look for an entire string to trim.

This fix will maintain the current behavior, simply eliminating the dupe
character in the set.

Should we instead mean to really trim the entire string, this needs a
different fix.