### PR TITLE
Use os.Args[0] when printing binary usage

### DIFF
--- a/gofmt.go
+++ b/gofmt.go
@@ -56,7 +56,7 @@ func report(err error) {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "usage: gofumpt [flags] [path ...]\n")
+	fmt.Fprintf(os.Stderr, "usage: %s [flags] [path ...]\n", filepath.Base(os.Args[0]))
 	flag.PrintDefaults()
 }
 

--- a/gofumports/goimports.go
+++ b/gofumports/goimports.go
@@ -69,7 +69,7 @@ func report(err error) {
 }
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "usage: gofumports [flags] [path ...]\n")
+	fmt.Fprintf(os.Stderr, "usage: %s [flags] [path ...]\n", filepath.Base(os.Args[0]))
 	flag.PrintDefaults()
 	os.Exit(2)
 }


### PR DESCRIPTION
While symlinking `goimports => gofumports` I noticed the usage (`gofumports --help`) output used the wrong binary name. This change should make `gofumports` print the right name, even if symlinked.