### PR TITLE
format: add nolint to rxCommentDirective

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -217,7 +217,8 @@ func (f *fumpter) printLength(node ast.Node) int {
 //   //export     | to mark cgo funcs for exporting
 //   //extern     | C function declarations for gccgo
 //   //sys(nb)?   | syscall function wrapper prototypes
-var rxCommentDirective = regexp.MustCompile(`^([a-z]+:|line\b|export\b|extern\b|sys(nb)?\b)`)
+//   //nolint     | nolint directive for golangci
+var rxCommentDirective = regexp.MustCompile(`^([a-z]+:|line\b|export\b|extern\b|sys(nb)?\b|nolint\b)`)
 
 // visit takes either an ast.Node or a []ast.Stmt.
 func (f *fumpter) applyPre(c *astutil.Cursor) {

--- a/testdata/scripts/comment-spaced.txt
+++ b/testdata/scripts/comment-spaced.txt
@@ -15,6 +15,12 @@ package p
 
 //lint:disablefoo
 
+//nolint
+
+//nolint // explanation
+
+//nolint:somelinter // explanation
+
 //not actually: a directive
 
 //TODO: do something
@@ -62,6 +68,12 @@ package p
 //go:unknowndirective
 
 //lint:disablefoo
+
+//nolint
+
+//nolint // explanation
+
+//nolint:somelinter // explanation
 
 // not actually: a directive
 


### PR DESCRIPTION
gofumpt has been added to golangci-lint as of v1.28. Golangci-lint also has a [`nolintlint` linter](https://github.com/golangci/golangci-lint/blob/master/pkg/golinters/nolintlint/README.md) that makes sure the `//nolint` directives don't start with a space. This is conflicting with `gofumpt` that forces a space to be added.

This PR adds `nolint` to `rxCommentDirective` to make sure no spaces are added.