### PR TITLE
Remove newlines between uncommented interface method signatures

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -352,6 +352,20 @@ func (f *fumpter) applyPre(c *astutil.Cursor) {
 			node.Rparen = token.NoPos
 		}
 
+		// Remove newlines between uncommented interface method signatures.
+		if node.Tok == token.TYPE && len(node.Specs) == 1 {
+			spec := node.Specs[0].(*ast.TypeSpec)
+			if iface, ok := spec.Type.(*ast.InterfaceType); ok {
+				methods := iface.Methods.List
+				for i := range methods {
+					if i >= len(methods)-1 || methods[i].Doc != nil || methods[i+1].Doc != nil {
+						continue
+					}
+					f.removeLinesBetween(methods[i].Pos(), methods[i+1].End())
+				}
+			}
+		}
+
 	case *ast.BlockStmt:
 		f.stmts(node.List)
 		comments := f.commentsBetween(node.Lbrace, node.Rbrace)

--- a/testdata/scripts/interface.txt
+++ b/testdata/scripts/interface.txt
@@ -1,0 +1,58 @@
+gofumpt -w foo.go
+cmp foo.go foo.go.golden
+
+gofumpt -d foo.go.golden
+! stdout .
+
+-- foo.go --
+package p
+
+type i1 interface {
+
+	a(x int) int
+
+	b(x int) int
+
+	c(x int) int
+
+}
+
+type i2 interface {
+
+	// comment for a
+	a(x int) int
+
+	// comment for b
+	b(x int) int
+
+	c(x int) int
+
+	d(x int) int
+
+	// comment for e
+	e(x int) int
+
+}
+-- foo.go.golden --
+package p
+
+type i1 interface {
+	a(x int) int
+	b(x int) int
+	c(x int) int
+}
+
+type i2 interface {
+
+	// comment for a
+	a(x int) int
+
+	// comment for b
+	b(x int) int
+
+	c(x int) int
+	d(x int) int
+
+	// comment for e
+	e(x int) int
+}


### PR DESCRIPTION
I believe this successfully implements the suggestion for interfaces discussed in #85.