### PR TITLE
format: provide the "simplify" feature

### DIFF
--- a/format/simplify.go
+++ b/format/simplify.go
@@ -2,12 +2,14 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main
+package format
 
 import (
 	"go/ast"
 	"go/token"
 	"reflect"
+
+	"mvdan.cc/gofumpt/internal/util"
 )
 
 type simplifier struct{}
@@ -106,7 +108,7 @@ func (s simplifier) simplifyLiteral(typ reflect.Value, astType, x ast.Expr, px *
 	// matches the outer literal's element type exactly, the inner
 	// literal type may be omitted
 	if inner, ok := x.(*ast.CompositeLit); ok {
-		if match(nil, typ, reflect.ValueOf(inner.Type)) {
+		if util.Match(nil, typ, reflect.ValueOf(inner.Type)) {
 			inner.Type = nil
 		}
 	}
@@ -116,7 +118,7 @@ func (s simplifier) simplifyLiteral(typ reflect.Value, astType, x ast.Expr, px *
 	if ptr, ok := astType.(*ast.StarExpr); ok {
 		if addr, ok := x.(*ast.UnaryExpr); ok && addr.Op == token.AND {
 			if inner, ok := addr.X.(*ast.CompositeLit); ok {
-				if match(nil, reflect.ValueOf(ptr.X), reflect.ValueOf(inner.Type)) {
+				if util.Match(nil, reflect.ValueOf(ptr.X), reflect.ValueOf(inner.Type)) {
 					inner.Type = nil // drop T
 					*px = inner      // drop &
 				}
@@ -130,7 +132,7 @@ func isBlank(x ast.Expr) bool {
 	return ok && ident.Name == "_"
 }
 
-func simplify(f *ast.File) {
+func Simplify(f *ast.File) {
 	// remove empty declarations such as "const ()", etc
 	removeEmptyDeclGroups(f)
 

--- a/gofmt.go
+++ b/gofmt.go
@@ -119,7 +119,7 @@ func processFile(filename string, in io.Reader, out io.Writer, stdin bool) error
 	ast.SortImports(fileSet, file)
 
 	if *simplifyAST {
-		simplify(file)
+		gformat.Simplify(file)
 	}
 
 	// Apply gofumpt's changes before we print the code in gofumpt's format.

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,243 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package util implements a series of helpers to manipulate AST fields.
+
+package util
+
+import (
+	"go/ast"
+	"go/token"
+	"reflect"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// Values/types for special cases.
+var (
+	objectPtrNil = reflect.ValueOf((*ast.Object)(nil))
+	scopePtrNil  = reflect.ValueOf((*ast.Scope)(nil))
+
+	identType     = reflect.TypeOf((*ast.Ident)(nil))
+	objectPtrType = reflect.TypeOf((*ast.Object)(nil))
+	positionType  = reflect.TypeOf(token.NoPos)
+	callExprType  = reflect.TypeOf((*ast.CallExpr)(nil))
+	scopePtrType  = reflect.TypeOf((*ast.Scope)(nil))
+)
+
+// set is a wrapper for x.Set(y); it protects the caller from panics if x cannot be changed to y.
+func set(x, y reflect.Value) {
+	// don't bother if x cannot be set or y is invalid
+	if !x.CanSet() || !y.IsValid() {
+		return
+	}
+	defer func() {
+		if x := recover(); x != nil {
+			if s, ok := x.(string); ok &&
+				(strings.Contains(s, "type mismatch") || strings.Contains(s, "not assignable")) {
+				// x cannot be set to y - ignore this rewrite
+				return
+			}
+			panic(x)
+		}
+	}()
+	x.Set(y)
+}
+
+func isWildcard(s string) bool {
+	rune, size := utf8.DecodeRuneInString(s)
+	return size == len(s) && unicode.IsLower(rune)
+}
+
+// Apply replaces each AST field x in val with f(x), returning val.
+// To avoid extra conversions, f operates on the reflect.Value form.
+func Apply(f func(reflect.Value) reflect.Value, val reflect.Value) reflect.Value {
+	if !val.IsValid() {
+		return reflect.Value{}
+	}
+
+	// *ast.Objects introduce cycles and are likely incorrect after
+	// rewrite; don't follow them but replace with nil instead
+	if val.Type() == objectPtrType {
+		return objectPtrNil
+	}
+
+	// similarly for scopes: they are likely incorrect after a rewrite;
+	// replace them with nil
+	if val.Type() == scopePtrType {
+		return scopePtrNil
+	}
+
+	switch v := reflect.Indirect(val); v.Kind() {
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			e := v.Index(i)
+			set(e, f(e))
+		}
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			e := v.Field(i)
+			set(e, f(e))
+		}
+	case reflect.Interface:
+		e := v.Elem()
+		set(v, f(e))
+	}
+	return val
+}
+
+// Match reports whether pattern matches val,
+// recording wildcard submatches in m.
+// If m == nil, match checks whether pattern == val.
+func Match(m map[string]reflect.Value, pattern, val reflect.Value) bool {
+	// Wildcard matches any expression. If it appears multiple
+	// times in the pattern, it must match the same expression
+	// each time.
+	if m != nil && pattern.IsValid() && pattern.Type() == identType {
+		name := pattern.Interface().(*ast.Ident).Name
+		if isWildcard(name) && val.IsValid() {
+			// wildcards only match valid (non-nil) expressions.
+			if _, ok := val.Interface().(ast.Expr); ok && !val.IsNil() {
+				if old, ok := m[name]; ok {
+					return Match(nil, old, val)
+				}
+				m[name] = val
+				return true
+			}
+		}
+	}
+
+	// Otherwise, pattern and val must match recursively.
+	if !pattern.IsValid() || !val.IsValid() {
+		return !pattern.IsValid() && !val.IsValid()
+	}
+	if pattern.Type() != val.Type() {
+		return false
+	}
+
+	// Special cases.
+	switch pattern.Type() {
+	case identType:
+		// For identifiers, only the names need to match
+		// (and none of the other *ast.Object information).
+		// This is a common case, handle it all here instead
+		// of recursing down any further via reflection.
+		p := pattern.Interface().(*ast.Ident)
+		v := val.Interface().(*ast.Ident)
+		return p == nil && v == nil || p != nil && v != nil && p.Name == v.Name
+	case objectPtrType, positionType:
+		// object pointers and token positions always match
+		return true
+	case callExprType:
+		// For calls, the Ellipsis fields (token.Position) must
+		// match since that is how f(x) and f(x...) are different.
+		// Check them here but fall through for the remaining fields.
+		p := pattern.Interface().(*ast.CallExpr)
+		v := val.Interface().(*ast.CallExpr)
+		if p.Ellipsis.IsValid() != v.Ellipsis.IsValid() {
+			return false
+		}
+	}
+
+	p := reflect.Indirect(pattern)
+	v := reflect.Indirect(val)
+	if !p.IsValid() || !v.IsValid() {
+		return !p.IsValid() && !v.IsValid()
+	}
+
+	switch p.Kind() {
+	case reflect.Slice:
+		if p.Len() != v.Len() {
+			return false
+		}
+		for i := 0; i < p.Len(); i++ {
+			if !Match(m, p.Index(i), v.Index(i)) {
+				return false
+			}
+		}
+		return true
+
+	case reflect.Struct:
+		for i := 0; i < p.NumField(); i++ {
+			if !Match(m, p.Field(i), v.Field(i)) {
+				return false
+			}
+		}
+		return true
+
+	case reflect.Interface:
+		return Match(m, p.Elem(), v.Elem())
+	}
+
+	// Handle token integers, etc.
+	return p.Interface() == v.Interface()
+}
+
+// Subst returns a copy of pattern with values from m substituted in place
+// of wildcards and pos used as the position of tokens from the pattern.
+// if m == nil, subst returns a copy of pattern and doesn't change the line
+// number information.
+func Subst(m map[string]reflect.Value, pattern reflect.Value, pos reflect.Value) reflect.Value {
+	if !pattern.IsValid() {
+		return reflect.Value{}
+	}
+
+	// Wildcard gets replaced with map value.
+	if m != nil && pattern.Type() == identType {
+		name := pattern.Interface().(*ast.Ident).Name
+		if isWildcard(name) {
+			if old, ok := m[name]; ok {
+				return Subst(nil, old, reflect.Value{})
+			}
+		}
+	}
+
+	if pos.IsValid() && pattern.Type() == positionType {
+		// use new position only if old position was valid in the first place
+		if old := pattern.Interface().(token.Pos); !old.IsValid() {
+			return pattern
+		}
+		return pos
+	}
+
+	// Otherwise copy.
+	switch p := pattern; p.Kind() {
+	case reflect.Slice:
+		if p.IsNil() {
+			// Do not turn nil slices into empty slices. go/ast
+			// guarantees that certain lists will be nil if not
+			// populated.
+			return reflect.Zero(p.Type())
+		}
+		v := reflect.MakeSlice(p.Type(), p.Len(), p.Len())
+		for i := 0; i < p.Len(); i++ {
+			v.Index(i).Set(Subst(m, p.Index(i), pos))
+		}
+		return v
+
+	case reflect.Struct:
+		v := reflect.New(p.Type()).Elem()
+		for i := 0; i < p.NumField(); i++ {
+			v.Field(i).Set(Subst(m, p.Field(i), pos))
+		}
+		return v
+
+	case reflect.Ptr:
+		v := reflect.New(p.Type()).Elem()
+		if elem := p.Elem(); elem.IsValid() {
+			v.Set(Subst(m, elem, pos).Addr())
+		}
+		return v
+
+	case reflect.Interface:
+		v := reflect.New(p.Type()).Elem()
+		if elem := p.Elem(); elem.IsValid() {
+			v.Set(Subst(m, elem, pos))
+		}
+		return v
+	}
+
+	return pattern
+}

--- a/rewrite.go
+++ b/rewrite.go
@@ -8,12 +8,11 @@ import (
 	"fmt"
 	"go/ast"
 	"go/parser"
-	"go/token"
 	"os"
 	"reflect"
 	"strings"
-	"unicode"
-	"unicode/utf8"
+
+	"mvdan.cc/gofumpt/internal/util"
 )
 
 func initRewrite() {
@@ -66,244 +65,17 @@ func rewriteFile(pattern, replace ast.Expr, p *ast.File) *ast.File {
 		if !val.IsValid() {
 			return reflect.Value{}
 		}
-		val = apply(rewriteVal, val)
+		val = util.Apply(rewriteVal, val)
 		for k := range m {
 			delete(m, k)
 		}
-		if match(m, pat, val) {
-			val = subst(m, repl, reflect.ValueOf(val.Interface().(ast.Node).Pos()))
+		if util.Match(m, pat, val) {
+			val = util.Subst(m, repl, reflect.ValueOf(val.Interface().(ast.Node).Pos()))
 		}
 		return val
 	}
 
-	r := apply(rewriteVal, reflect.ValueOf(p)).Interface().(*ast.File)
+	r := util.Apply(rewriteVal, reflect.ValueOf(p)).Interface().(*ast.File)
 	r.Comments = cmap.Filter(r).Comments() // recreate comments list
 	return r
-}
-
-// set is a wrapper for x.Set(y); it protects the caller from panics if x cannot be changed to y.
-func set(x, y reflect.Value) {
-	// don't bother if x cannot be set or y is invalid
-	if !x.CanSet() || !y.IsValid() {
-		return
-	}
-	defer func() {
-		if x := recover(); x != nil {
-			if s, ok := x.(string); ok &&
-				(strings.Contains(s, "type mismatch") || strings.Contains(s, "not assignable")) {
-				// x cannot be set to y - ignore this rewrite
-				return
-			}
-			panic(x)
-		}
-	}()
-	x.Set(y)
-}
-
-// Values/types for special cases.
-var (
-	objectPtrNil = reflect.ValueOf((*ast.Object)(nil))
-	scopePtrNil  = reflect.ValueOf((*ast.Scope)(nil))
-
-	identType     = reflect.TypeOf((*ast.Ident)(nil))
-	objectPtrType = reflect.TypeOf((*ast.Object)(nil))
-	positionType  = reflect.TypeOf(token.NoPos)
-	callExprType  = reflect.TypeOf((*ast.CallExpr)(nil))
-	scopePtrType  = reflect.TypeOf((*ast.Scope)(nil))
-)
-
-// apply replaces each AST field x in val with f(x), returning val.
-// To avoid extra conversions, f operates on the reflect.Value form.
-func apply(f func(reflect.Value) reflect.Value, val reflect.Value) reflect.Value {
-	if !val.IsValid() {
-		return reflect.Value{}
-	}
-
-	// *ast.Objects introduce cycles and are likely incorrect after
-	// rewrite; don't follow them but replace with nil instead
-	if val.Type() == objectPtrType {
-		return objectPtrNil
-	}
-
-	// similarly for scopes: they are likely incorrect after a rewrite;
-	// replace them with nil
-	if val.Type() == scopePtrType {
-		return scopePtrNil
-	}
-
-	switch v := reflect.Indirect(val); v.Kind() {
-	case reflect.Slice:
-		for i := 0; i < v.Len(); i++ {
-			e := v.Index(i)
-			set(e, f(e))
-		}
-	case reflect.Struct:
-		for i := 0; i < v.NumField(); i++ {
-			e := v.Field(i)
-			set(e, f(e))
-		}
-	case reflect.Interface:
-		e := v.Elem()
-		set(v, f(e))
-	}
-	return val
-}
-
-func isWildcard(s string) bool {
-	rune, size := utf8.DecodeRuneInString(s)
-	return size == len(s) && unicode.IsLower(rune)
-}
-
-// match reports whether pattern matches val,
-// recording wildcard submatches in m.
-// If m == nil, match checks whether pattern == val.
-func match(m map[string]reflect.Value, pattern, val reflect.Value) bool {
-	// Wildcard matches any expression. If it appears multiple
-	// times in the pattern, it must match the same expression
-	// each time.
-	if m != nil && pattern.IsValid() && pattern.Type() == identType {
-		name := pattern.Interface().(*ast.Ident).Name
-		if isWildcard(name) && val.IsValid() {
-			// wildcards only match valid (non-nil) expressions.
-			if _, ok := val.Interface().(ast.Expr); ok && !val.IsNil() {
-				if old, ok := m[name]; ok {
-					return match(nil, old, val)
-				}
-				m[name] = val
-				return true
-			}
-		}
-	}
-
-	// Otherwise, pattern and val must match recursively.
-	if !pattern.IsValid() || !val.IsValid() {
-		return !pattern.IsValid() && !val.IsValid()
-	}
-	if pattern.Type() != val.Type() {
-		return false
-	}
-
-	// Special cases.
-	switch pattern.Type() {
-	case identType:
-		// For identifiers, only the names need to match
-		// (and none of the other *ast.Object information).
-		// This is a common case, handle it all here instead
-		// of recursing down any further via reflection.
-		p := pattern.Interface().(*ast.Ident)
-		v := val.Interface().(*ast.Ident)
-		return p == nil && v == nil || p != nil && v != nil && p.Name == v.Name
-	case objectPtrType, positionType:
-		// object pointers and token positions always match
-		return true
-	case callExprType:
-		// For calls, the Ellipsis fields (token.Position) must
-		// match since that is how f(x) and f(x...) are different.
-		// Check them here but fall through for the remaining fields.
-		p := pattern.Interface().(*ast.CallExpr)
-		v := val.Interface().(*ast.CallExpr)
-		if p.Ellipsis.IsValid() != v.Ellipsis.IsValid() {
-			return false
-		}
-	}
-
-	p := reflect.Indirect(pattern)
-	v := reflect.Indirect(val)
-	if !p.IsValid() || !v.IsValid() {
-		return !p.IsValid() && !v.IsValid()
-	}
-
-	switch p.Kind() {
-	case reflect.Slice:
-		if p.Len() != v.Len() {
-			return false
-		}
-		for i := 0; i < p.Len(); i++ {
-			if !match(m, p.Index(i), v.Index(i)) {
-				return false
-			}
-		}
-		return true
-
-	case reflect.Struct:
-		for i := 0; i < p.NumField(); i++ {
-			if !match(m, p.Field(i), v.Field(i)) {
-				return false
-			}
-		}
-		return true
-
-	case reflect.Interface:
-		return match(m, p.Elem(), v.Elem())
-	}
-
-	// Handle token integers, etc.
-	return p.Interface() == v.Interface()
-}
-
-// subst returns a copy of pattern with values from m substituted in place
-// of wildcards and pos used as the position of tokens from the pattern.
-// if m == nil, subst returns a copy of pattern and doesn't change the line
-// number information.
-func subst(m map[string]reflect.Value, pattern reflect.Value, pos reflect.Value) reflect.Value {
-	if !pattern.IsValid() {
-		return reflect.Value{}
-	}
-
-	// Wildcard gets replaced with map value.
-	if m != nil && pattern.Type() == identType {
-		name := pattern.Interface().(*ast.Ident).Name
-		if isWildcard(name) {
-			if old, ok := m[name]; ok {
-				return subst(nil, old, reflect.Value{})
-			}
-		}
-	}
-
-	if pos.IsValid() && pattern.Type() == positionType {
-		// use new position only if old position was valid in the first place
-		if old := pattern.Interface().(token.Pos); !old.IsValid() {
-			return pattern
-		}
-		return pos
-	}
-
-	// Otherwise copy.
-	switch p := pattern; p.Kind() {
-	case reflect.Slice:
-		if p.IsNil() {
-			// Do not turn nil slices into empty slices. go/ast
-			// guarantees that certain lists will be nil if not
-			// populated.
-			return reflect.Zero(p.Type())
-		}
-		v := reflect.MakeSlice(p.Type(), p.Len(), p.Len())
-		for i := 0; i < p.Len(); i++ {
-			v.Index(i).Set(subst(m, p.Index(i), pos))
-		}
-		return v
-
-	case reflect.Struct:
-		v := reflect.New(p.Type()).Elem()
-		for i := 0; i < p.NumField(); i++ {
-			v.Field(i).Set(subst(m, p.Field(i), pos))
-		}
-		return v
-
-	case reflect.Ptr:
-		v := reflect.New(p.Type()).Elem()
-		if elem := p.Elem(); elem.IsValid() {
-			v.Set(subst(m, elem, pos).Addr())
-		}
-		return v
-
-	case reflect.Interface:
-		v := reflect.New(p.Type()).Elem()
-		if elem := p.Elem(); elem.IsValid() {
-			v.Set(subst(m, elem, pos))
-		}
-		return v
-	}
-
-	return pattern
 }


### PR DESCRIPTION
Given that `gofumpt` enforces `gofmt`'s simplify flag, it's weird that
it's not applied via the Go API. Pure Go users like gopls are getting a
different experience, so this should be fixed.

This patch adds the support of the `simplify` feature via the Go API.

Fixes https://github.com/mvdan/gofumpt/issues/115

Signed-off-by: Kailun Qin <kailun.qin@intel.com>