### PR TITLE
Remove newlines between uncommented interface method signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,55 @@ var _ = map[string]string{
 
 </details>
 
+Remove unnecessary empty lines from interfaces
+
+<details><summary><i>example</i></summary>
+
+```
+type i interface {
+
+	// comment for a
+	a(x int) int
+
+	// comment between a and b
+
+	// comment for b
+	b(x int) int
+
+	// comment between b and c
+
+	c(x int) int
+
+	d(x int) int
+
+	// comment for e
+	e(x int) int
+
+}
+```
+
+```
+type i interface {
+	// comment for a
+	a(x int) int
+
+	// comment between a and b
+
+	// comment for b
+	b(x int) int
+
+	// comment between b and c
+
+	c(x int) int
+	d(x int) int
+
+	// comment for e
+	e(x int) int
+}
+```
+
+</details>
+
 #### Extra rules behind `-extra`
 
 Adjacent parameters with the same type should be grouped together

--- a/testdata/scripts/interface.txt
+++ b/testdata/scripts/interface.txt
@@ -1,0 +1,168 @@
+gofumpt -w foo.go
+cmp foo.go foo.go.golden
+
+gofumpt -d foo.go.golden
+! stdout .
+
+-- foo.go --
+package p
+
+type i1 interface {
+
+	a(x int) int
+
+	b(x int) int
+
+	c(x int) int
+
+}
+
+type i2 interface {
+
+	// comment for a
+	a(x int) int
+
+	// comment between a and b
+
+	// comment for b
+	b(x int) int
+
+	// comment between b and c
+
+	c(x int) int
+
+	d(x int) int
+
+	// comment for e
+	e(x int) int
+
+}
+
+type i3 interface {
+	a(x int) int
+
+	// standalone comment
+
+	b(x int) int
+}
+
+type leadingLine1 interface {
+
+
+	a(x int) int
+}
+
+type leadingLine2 interface {
+
+	a(x int) int
+}
+
+type leadingLine3 interface {
+
+	// comment
+	a(x int) int
+}
+
+type leadingLine4 interface {
+	// comment
+
+	a(x int) int
+}
+
+type leadingLine5 interface {
+	// comment
+
+	// comment for a
+	a(x int) int
+}
+
+type leadingLine6 interface {
+
+	// comment
+
+	// comment for a
+	a(x int) int
+}
+
+type leadingLine7 interface {
+
+
+	// comment
+
+	// comment for a
+	a(x int) int
+}
+-- foo.go.golden --
+package p
+
+type i1 interface {
+	a(x int) int
+	b(x int) int
+	c(x int) int
+}
+
+type i2 interface {
+	// comment for a
+	a(x int) int
+
+	// comment between a and b
+
+	// comment for b
+	b(x int) int
+
+	// comment between b and c
+
+	c(x int) int
+	d(x int) int
+
+	// comment for e
+	e(x int) int
+}
+
+type i3 interface {
+	a(x int) int
+
+	// standalone comment
+
+	b(x int) int
+}
+
+type leadingLine1 interface {
+	a(x int) int
+}
+
+type leadingLine2 interface {
+	a(x int) int
+}
+
+type leadingLine3 interface {
+	// comment
+	a(x int) int
+}
+
+type leadingLine4 interface {
+	// comment
+
+	a(x int) int
+}
+
+type leadingLine5 interface {
+	// comment
+
+	// comment for a
+	a(x int) int
+}
+
+type leadingLine6 interface {
+	// comment
+
+	// comment for a
+	a(x int) int
+}
+
+type leadingLine7 interface {
+	// comment
+
+	// comment for a
+	a(x int) int
+}


### PR DESCRIPTION
this addresses the comments on PR#95 since the author ghosted

implements the suggestion for interfaces discussed in #85