### PR TITLE
avoid using sign.Results.Closing when it's invalid

### DIFF
--- a/gofmt.go
+++ b/gofmt.go
@@ -197,6 +197,10 @@ func main() {
 }
 
 func gofumptMain() {
+	// Ensure our parsed files never start with base 1,
+	// to ensure that using token.NoPos+1 will panic.
+	fileSet.AddFile("gofumpt_base.go", 1, 10)
+
 	flag.Usage = usage
 	flag.Parse()
 

--- a/testdata/scripts/func-newlines.txt
+++ b/testdata/scripts/func-newlines.txt
@@ -249,6 +249,15 @@ func multilineParamsWithoutEmptyLineWithComment(p1 string,
 	// comment
 	println("body")
 }
+
+// Same as the others above, but with a single result parameter without
+// parentheses. This used to cause token.File.Offset crashes.
+func f(p1 string,
+	p2 string) int {
+
+	println("body")
+	return 0
+}
 -- foo.go.golden --
 package p
 
@@ -448,4 +457,13 @@ func multilineParamsWithoutEmptyLineWithComment(p1 string,
 	p2 string) {
 	// comment
 	println("body")
+}
+
+// Same as the others above, but with a single result parameter without
+// parentheses. This used to cause token.File.Offset crashes.
+func f(p1 string,
+	p2 string,
+) int {
+	println("body")
+	return 0
 }


### PR DESCRIPTION
(see commit message)