### PR TITLE
format: treat `noinspection` as comment directive

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -306,17 +306,18 @@ func (f *fumpter) lineEnd(line int) token.Pos {
 
 // rxCommentDirective covers all common Go comment directives:
 //
-//   //go:         | standard Go directives, like go:noinline
-//   //some-words: | similar to the syntax above, like lint:ignore or go-sumtype:decl
-//   //line        | inserted line information for cmd/compile
-//   //export      | to mark cgo funcs for exporting
-//   //extern      | C function declarations for gccgo
-//   //sys(nb)?    | syscall function wrapper prototypes
-//   //nolint      | nolint directive for golangci
+//   //go:          | standard Go directives, like go:noinline
+//   //some-words:  | similar to the syntax above, like lint:ignore or go-sumtype:decl
+//   //line         | inserted line information for cmd/compile
+//   //export       | to mark cgo funcs for exporting
+//   //extern       | C function declarations for gccgo
+//   //sys(nb)?     | syscall function wrapper prototypes
+//   //nolint       | nolint directive for golangci
+//   //noinspection | noinspection directive for GoLand and friends
 //
 // Note that the "some-words:" matching expects a letter afterward, such as
 // "go:generate", to prevent matching false positives like "https://site".
-var rxCommentDirective = regexp.MustCompile(`^([a-z-]+:[a-z]+|line\b|export\b|extern\b|sys(nb)?\b|nolint\b)`)
+var rxCommentDirective = regexp.MustCompile(`^([a-z-]+:[a-z]+|line\b|export\b|extern\b|sys(nb)?\b|no(lint|inspection)\b)`)
 
 func (f *fumpter) applyPre(c *astutil.Cursor) {
 	f.splitLongLine(c)

--- a/testdata/scripts/comment-spaced.txt
+++ b/testdata/scripts/comment-spaced.txt
@@ -24,6 +24,10 @@ package p
 
 //nolint:somelinter // explanation
 
+//noinspection ALL
+
+//noinspection foo,bar
+
 //not actually: a directive
 
 //https://just.one/url
@@ -82,6 +86,10 @@ package p
 //nolint // explanation
 
 //nolint:somelinter // explanation
+
+//noinspection ALL
+
+//noinspection foo,bar
 
 // not actually: a directive
 


### PR DESCRIPTION
Used by some versions of GoLand and friends,
https://www.jetbrains.com/help/go/disabling-and-enabling-inspections.html

New versions use `//goland:noinspection` instead/additionally, but it doesn't hurt much to support the older (and still the only documented) one.