### PR TITLE
fix panic with go1.18 workspaces

### DIFF
--- a/gofmt.go
+++ b/gofmt.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"go/ast"
@@ -134,10 +135,11 @@ func processFile(filename string, in io.Reader, out io.Writer, stdin bool) error
 	// Apply gofumpt's changes before we print the code in gofumpt's format.
 
 	if *langVersion == "" {
-		out, err := exec.Command("go", "list", "-m", "-f", "{{.GoVersion}}").Output()
-		out = bytes.TrimSpace(out)
+		out, err := exec.Command("go", "mod", "edit", "-json").Output()
 		if err == nil && len(out) > 0 {
-			*langVersion = string(out)
+			var mod struct{ Go string }
+			_ = json.Unmarshal(out, &mod)
+			*langVersion = mod.Go
 		}
 	}
 

--- a/testdata/scripts/workspaces.txt
+++ b/testdata/scripts/workspaces.txt
@@ -1,0 +1,33 @@
+[!go1.18] skip
+
+# Octal literal prefixes were introduced in Go 1.13. If we are outside of the
+# module, language version should not be set.
+gofumpt a/go112
+cmp stdout a/go112
+
+cd a
+gofumpt go112
+cmp stdout go113
+
+-- a/go112 --
+package main
+
+const x = 0777
+-- a/go113 --
+package main
+
+const x = 0o777
+-- go.work --
+go 1.18
+use ./a
+use ./b
+-- a/go.mod --
+module a
+go 1.18
+-- a/a.go --
+package a
+-- b/go.mod --
+module b
+go 1.18
+-- b/b.go --
+package b


### PR DESCRIPTION
This PR fixes a panic in projects that use go1.18 workspace—`go list -m -f {{.Version}}` returns a newline-separated list of Go versions for all modules in the workspace, and it panics on semver check. Now, instead of using `go list`, we extract Go version from `go mod edit -json` output.

https://github.com/mvdan/gofumpt/blob/f32c372f2e95fd5c97be3e6f2585ee7571b68846/format/format.go#L96-L98

<details>


```
panic: invalid semver string: "v1.18\n1.18"

goroutine 1 [running]:
mvdan.cc/gofumpt/format.File(0xc0001065c0, 0xc000168100, {{0xc000014927?, 0xc000121400?}, 0xa?})
        mvdan.cc/gofumpt@v0.2.1/format/format.go:97 +0x3b4
main.processFile({0x7fff9795d60a, 0x4}, {0x0?, 0x0?}, {0x6b26d8, 0xc00000e018}, 0x38?)
        mvdan.cc/gofumpt@v0.2.1/gofmt.go:144 +0x385
main.gofumptMain()
        mvdan.cc/gofumpt@v0.2.1/gofmt.go:268 +0x4e5
main.main()
        mvdan.cc/gofumpt@v0.2.1/gofmt.go:209 +0x19
```
</details>