### PR TITLE
Remove empty lines surrounding the lone comments in struct

### DIFF
--- a/testdata/scripts/block-empty.txt
+++ b/testdata/scripts/block-empty.txt
@@ -20,7 +20,42 @@ func f() {
 		// lone comment
 
 	}
+
+	type S struct {
+
+
+		// lone comment
+		
+		
+	}
+
+	type I interface {
+
+
+		// lone comment
+		
+		
+	}
+
+
 }
+
+type SOut struct {
+
+	// lone comment
+	
+}
+
+type IOut interface {
+
+	
+	// lone comment
+
+
+}
+
+
+
 -- foo.go.golden --
 package p
 
@@ -34,4 +69,20 @@ func f() {
 	{
 		// lone comment
 	}
+
+	type S struct {
+		// lone comment
+	}
+
+	type I interface {
+		// lone comment
+	}
+}
+
+type SOut struct {
+	// lone comment
+}
+
+type IOut interface {
+	// lone comment
 }


### PR DESCRIPTION
Remove empty lines surrounding comments in struct/interfaces. In short, converts
```
type S struct {

    // comment

}
```
to
```
type S struct {
    // comment
}
```

