### PR TITLE
README: Add installation instructions for Emacs lsp-mode ≥ 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,11 @@ require('lspconfig').gopls.setup({
 For [lsp-mode](https://emacs-lsp.github.io/lsp-mode/) users:
 
 ```elisp
+(setq lsp-go-use-gofumpt t)
+```
+
+For users of `lsp-mode` before `8.0.0`:
+```elisp
 (lsp-register-custom-settings
  '(("gopls.gofumpt" t)))
 ```


### PR DESCRIPTION
The Emacs [8.0.0 release](https://github.com/emacs-lsp/lsp-mode/releases/tag/8.0.0) of [lsp-mode](https://github.com/emacs-lsp/lsp-mode) exposed the gofump setting as a custom variable: https://github.com/emacs-lsp/lsp-mode/commit/b340d364b280b5bda939627ed90373b86837d664.

This PR updates the installation instructions with the new setting, while keeping the old method for versions below 8.0.0.