### PR TITLE
Extend README in several directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ and the `-s` flag is hidden as it is always enabled.
 
 ### Added rules
 
-No empty lines following an assignment operator
+**No empty lines following an assignment operator**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 func foo() {
     foo :=
         "bar"
 }
 ```
 
-```
+```go
 func foo() {
 	foo := "bar"
 }
@@ -45,11 +45,11 @@ func foo() {
 
 </details>
 
-No empty lines around function bodies
+**No empty lines around function bodies**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 func foo() {
 
 	println("bar")
@@ -57,7 +57,7 @@ func foo() {
 }
 ```
 
-```
+```go
 func foo() {
 	println("bar")
 }
@@ -65,11 +65,11 @@ func foo() {
 
 </details>
 
-Functions should separate `) {` where the indentation helps readability
+**Functions should separate `) {` where the indentation helps readability**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 func foo(s string,
 	i int) {
 	println("bar")
@@ -83,7 +83,7 @@ func bar(s string,
 }
 ```
 
-```
+```go
 func foo(s string,
 	i int,
 ) {
@@ -100,39 +100,18 @@ func bar(s string,
 
 </details>
 
-No empty lines around a lone statement (or comment) in a block
+**No empty lines around a lone statement (or comment) in a block**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 if err != nil {
 
 	return err
 }
 ```
 
-```
-if err != nil {
-	return err
-}
-```
-
-</details>
-
-No empty lines before a simple error check
-
-<details><summary><i>example</i></summary>
-
-```
-foo, err := processFoo()
-
-if err != nil {
-	return err
-}
-```
-
-```
-foo, err := processFoo()
+```go
 if err != nil {
 	return err
 }
@@ -140,11 +119,32 @@ if err != nil {
 
 </details>
 
-Composite literals should use newlines consistently
+**No empty lines before a simple error check**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
+```go
+foo, err := processFoo()
+
+if err != nil {
+	return err
+}
 ```
+
+```go
+foo, err := processFoo()
+if err != nil {
+	return err
+}
+```
+
+</details>
+
+**Composite literals should use newlines consistently**
+
+<details><summary><i>Example</i></summary>
+
+```go
 // A newline before or after an element requires newlines for the opening and
 // closing braces.
 var ints = []int{1, 2,
@@ -160,7 +160,7 @@ var matrix = [][]int{
 }
 ```
 
-```
+```go
 var ints = []int{
 	1, 2,
 	3, 4,
@@ -177,11 +177,11 @@ var matrix = [][]int{
 
 </details>
 
-Empty field lists should use a single line
+**Empty field lists should use a single line**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 var V interface {
 } = 3
 
@@ -192,7 +192,7 @@ func F(
 )
 ```
 
-```
+```go
 var V interface{} = 3
 
 type T struct{}
@@ -202,11 +202,11 @@ func F()
 
 </details>
 
-`std` imports must be in a separate group at the top
+**`std` imports must be in a separate group at the top**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 import (
 	"foo.com/bar"
 
@@ -216,7 +216,7 @@ import (
 )
 ```
 
-```
+```go
 import (
 	"io"
 	"io/ioutil"
@@ -227,18 +227,18 @@ import (
 
 </details>
 
-Short case clauses should take a single line
+**Short case clauses should take a single line**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 switch c {
 case 'a', 'b',
 	'c', 'd':
 }
 ```
 
-```
+```go
 switch c {
 case 'a', 'b', 'c', 'd':
 }
@@ -246,11 +246,11 @@ case 'a', 'b', 'c', 'd':
 
 </details>
 
-Multiline top-level declarations must be separated by empty lines
+**Multiline top-level declarations must be separated by empty lines**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 func foo() {
 	println("multiline foo")
 }
@@ -259,7 +259,7 @@ func bar() {
 }
 ```
 
-```
+```go
 func foo() {
 	println("multiline foo")
 }
@@ -271,33 +271,33 @@ func bar() {
 
 </details>
 
-Single var declarations should not be grouped with parentheses
+**Single var declarations should not be grouped with parentheses**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 var (
 	foo = "bar"
 )
 ```
 
-```
+```go
 var foo = "bar"
 ```
 
 </details>
 
-Contiguous top-level declarations should be grouped together
+**Contiguous top-level declarations should be grouped together**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 var nicer = "x"
 var with = "y"
 var alignment = "z"
 ```
 
-```
+```go
 var (
 	nicer     = "x"
 	with      = "y"
@@ -307,63 +307,60 @@ var (
 
 </details>
 
+**Simple var-declaration statements should use short assignments**
 
-Simple var-declaration statements should use short assignments
+<details><summary><i>Example</i></summary>
 
-<details><summary><i>example</i></summary>
-
-```
+```go
 var s = "somestring"
 ```
 
-```
+```go
 s := "somestring"
 ```
 
 </details>
 
+**The `-s` code simplification flag is enabled by default**
 
-The `-s` code simplification flag is enabled by default
+<details><summary><i>Example</i></summary>
 
-<details><summary><i>example</i></summary>
-
-```
+```go
 var _ = [][]int{[]int{1}}
 ```
 
-```
+```go
 var _ = [][]int{{1}}
 ```
 
 </details>
 
+**Octal integer literals should use the `0o` prefix on modules using Go 1.13 and later**
 
-Octal integer literals should use the `0o` prefix on modules using Go 1.13 and later
+<details><summary><i>Example</i></summary>
 
-<details><summary><i>example</i></summary>
-
-```
+```go
 const perm = 0755
 ```
 
-```
+```go
 const perm = 0o755
 ```
 
 </details>
 
-Comments which aren't Go directives should start with a whitespace
+**Comments which aren't Go directives should start with a whitespace**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 //go:noinline
 
 //Foo is awesome.
 func Foo() {}
 ```
 
-```
+```go
 //go:noinline
 
 // Foo is awesome.
@@ -372,11 +369,11 @@ func Foo() {}
 
 </details>
 
-Composite literals should not have leading or trailing empty lines
+**Composite literals should not have leading or trailing empty lines**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 var _ = []string{
 
 	"foo",
@@ -390,7 +387,7 @@ var _ = map[string]string{
 }
 ```
 
-```
+```go
 var _ = []string{
 	"foo",
 }
@@ -402,11 +399,11 @@ var _ = map[string]string{
 
 </details>
 
-Field lists should not have leading or trailing empty lines
+**Field lists should not have leading or trailing empty lines**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 type Person interface {
 
 	Name() string
@@ -422,7 +419,7 @@ type ZeroFields struct {
 }
 ```
 
-```
+```go
 type Person interface {
 	Name() string
 
@@ -438,15 +435,15 @@ type ZeroFields struct {
 
 #### Extra rules behind `-extra`
 
-Adjacent parameters with the same type should be grouped together
+**Adjacent parameters with the same type should be grouped together**
 
-<details><summary><i>example</i></summary>
+<details><summary><i>Example</i></summary>
 
-```
+```go
 func Foo(bar string, baz string) {}
 ```
 
-```
+```go
 func Foo(bar, baz string) {}
 ```
 

--- a/README.md
+++ b/README.md
@@ -496,7 +496,12 @@ When a window asks for settings, you can enter the following:
 
 To avoid unnecessary runs, you should disable all checkboxes in the *Advanced* section.
 
-#### Vim-go
+#### Vim
+
+The configuration depends on the plugin you are using: [vim-go](https://github.com/fatih/vim-go)
+or [govim](https://github.com/govim/govim).
+
+##### vim-go
 
 To configure `gopls` to use `gofumpt`:
 
@@ -505,7 +510,7 @@ let g:go_fmt_command="gopls"
 let g:go_gopls_gofumpt=1
 ```
 
-#### Govim
+##### govim
 
 To configure `gopls` to use `gofumpt`:
 


### PR DESCRIPTION
Hello again—sorry about the delay following #244. I've had quite a lot on.

This PR contains a few documentation changes; the branch is split into individually examinable commits. The [penultimate commit](https://github.com/mvdan/gofumpt/commit/067cda6980b700840520a50d56832856b65cfe0e) in the branch contains a few references to the sensitivity of gofumpt to the version of Go used to build it. I've also added a TOC and shuffled a few bits and pieces around.

Please don't be shy about telling me to change less (or to change more)! This is your repository, after all.

If all's well and you like the direction, I'll try to—in a later branch—take a look at adding a bit of usage documentation (e.g. around `-lang`) and extending what appears in the Go reference.