### PR TITLE
Add Helix instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,16 @@ For [eglot](https://github.com/joaotavora/eglot) users:
  '((:gopls . ((gofumpt . t)))))
 ```
 
+#### Helix
+
+When using the `gopls` language server, modify the Go settings in `~/.config/helix/languages.toml`:
+
+```toml
+[[language]]
+name = "go"
+config = { "formatting.gofumpt" = true }
+```
+
 #### Sublime Text
 
 With ST4, install the Sublime Text LSP extension according to [the documentation](https://github.com/sublimelsp/LSP),


### PR DESCRIPTION
This adds the necessary information to the readme to enable `gofumpt` in the [Helix](https://helix-editor.com) editor.