### PR TITLE
Don't add whitespaceto //NOSONAR comments

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -305,10 +305,11 @@ func (f *fumpter) lineEnd(line int) token.Pos {
 //	//sys(nb)?     | syscall function wrapper prototypes
 //	//nolint       | nolint directive for golangci
 //	//noinspection | noinspection directive for GoLand and friends
+//	//NOSONAR      | NOSONAR directive for SonarQube
 //
 // Note that the "some-words:" matching expects a letter afterward, such as
 // "go:generate", to prevent matching false positives like "https://site".
-var rxCommentDirective = regexp.MustCompile(`^([a-z-]+:[a-z]+|line\b|export\b|extern\b|sys(nb)?\b|no(lint|inspection)\b)`)
+var rxCommentDirective = regexp.MustCompile(`^([a-z-]+:[a-z]+|line\b|export\b|extern\b|sys(nb)?\b|no(lint|inspection)\b)|NOSONAR\b`)
 
 func (f *fumpter) applyPre(c *astutil.Cursor) {
 	f.splitLongLine(c)

--- a/testdata/script/comment-spaced.txtar
+++ b/testdata/script/comment-spaced.txtar
@@ -24,6 +24,10 @@ package p
 
 //nolint:somelinter // explanation
 
+//NOSONAR
+
+//NOSONAR // explanation
+
 //noinspection ALL
 
 //noinspection foo,bar
@@ -86,6 +90,10 @@ package p
 //nolint // explanation
 
 //nolint:somelinter // explanation
+
+//NOSONAR
+
+//NOSONAR // explanation
 
 //noinspection ALL
 


### PR DESCRIPTION
When using sonarqube, the `//NOSONAR` can be used to disable SONAR parsing for this line on false-positives.

See [here](https://docs.sonarcloud.io/appendices/frequently-asked-questions/).

This only works if there is no space between the slashes and the `NOSONAR`.


Just another exception to the rule :)