### PR TITLE
Update Helix editor config

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,9 +561,8 @@ For [eglot](https://github.com/joaotavora/eglot) users:
 When using the `gopls` language server, modify the Go settings in `~/.config/helix/languages.toml`:
 
 ```toml
-[[language]]
-name = "go"
-config = { "formatting.gofumpt" = true }
+[language-server.gopls.config]
+"formatting.gofumpt" = true
 ```
 
 #### Sublime Text


### PR DESCRIPTION
  Helix editor version 23.10 changes the way language servers are configured. See https://helix-editor.com/news/release-23-10-highlights.