### PR TITLE
#284 unconditionally remove leading and trailing lines from code blocks

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -522,11 +522,6 @@ func (f *fumpter) applyPre(c *astutil.Cursor) {
 			cond = parent.Cond
 		}
 
-		if len(node.List) > 1 && sign == nil {
-			// only if we have a single statement, or if
-			// it's a func body.
-			break
-		}
 		var bodyPos, bodyEnd token.Pos
 
 		if len(node.List) > 0 {


### PR DESCRIPTION
This implements as far as I can tell, the change needed for this [issue](https://github.com/mvdan/gofumpt/issues/284).

Unclear as to how where tests live at this time, but running `go test ./...` seems to still be working.