### PR TITLE
Clothe returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,25 @@ type ZeroFields struct {
 
 </details>
 
-#### Extra rules behind `-extra`
+**Avoid naked returns for the sake of clarity**
+
+<details><summary><i>Example</i></summary>
+
+```go
+func Foo() (err error) {
+	return
+}
+```
+
+```go
+func Foo() (err error) {
+	return err
+}
+```
+
+</details>
+
+### Extra rules behind `-extra`
 
 **Adjacent parameters with the same type should be grouped together**
 

--- a/testdata/script/clothe-returns.txtar
+++ b/testdata/script/clothe-returns.txtar
@@ -1,0 +1,74 @@
+exec gofumpt -w foo.go
+cmp foo.go foo.go.golden
+
+exec gofumpt -d foo.go.golden
+! stdout .
+
+-- foo.go --
+package p
+
+func foo() (err error) {
+	if true {
+		return
+	}
+	if false {
+		return func() (err2 error) {
+			return
+		}
+	}
+	return
+}
+
+func bar() (_ int, err error) {
+	return
+}
+
+func baz() (a, b, c int) {
+	return
+}
+
+func qux() (file string, b int, err error) {
+	if err == nil {
+		return
+	}
+
+	// A comment
+	return
+}
+
+// quux does quuxy things
+func quux() {}
+-- foo.go.golden --
+package p
+
+func foo() (err error) {
+	if true {
+		return err
+	}
+	if false {
+		return func() (err2 error) {
+			return err2
+		}
+	}
+	return err
+}
+
+func bar() (_ int, err error) {
+	return
+}
+
+func baz() (a, b, c int) {
+	return a, b, c
+}
+
+func qux() (file string, b int, err error) {
+	if err == nil {
+		return file, b, err
+	}
+
+	// A comment
+	return file, b, err
+}
+
+// quux does quuxy things
+func quux() {}


### PR DESCRIPTION
Fixes #285

<hr>

At present, this transformation ignores naked returns in functions with blank-named return values (i.e. `func() (_ int, err error)`) because rewriting them requires a literal zero value, which seemed unnecessary to evaluate the usefulness of this rule. It can be updated if we decide to move forward with this.

There's probably also room to improve the algorithm used to determine the nearest function parent to a given return statement. I didn't see any prior art within this project to copy, so I chose an easy option to implement, which I expect is enough to evaluate the usefulness. And we can optimize if deemed necessary.