### PR TITLE
Remove redundant package aliases from import blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,24 @@ import (
 
 </details>
 
+**Redundant package aliases are removed**
+
+<details><summary><i>Example</i></summary>
+
+```go
+import (
+	math "math"
+)
+```
+
+```go
+import (
+	"math"
+)
+```
+
+</details>
+
 **Short case clauses should take a single line**
 
 <details><summary><i>Example</i></summary>

--- a/testdata/script/std-imports.txtar
+++ b/testdata/script/std-imports.txtar
@@ -48,7 +48,7 @@ import (
 import (
 	"foo.local"
 	"foo.local/three"
-	math "math"
+	maths "math"
 )
 
 import (
@@ -99,6 +99,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
 )
+
+// Redundant package aliases are removed.
+import (
+	filepath "path/filepath"
+	"time"
+)
 -- foo.go.golden --
 package p
 
@@ -135,7 +141,7 @@ import (
 
 // We need to split std vs non-std in this case too.
 import (
-	math "math"
+	maths "math"
 
 	"foo.local"
 	"foo.local/three"
@@ -190,4 +196,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/yaml"
+)
+
+// Redundant package aliases are removed.
+import (
+	"path/filepath"
+	"time"
 )


### PR DESCRIPTION
I noticed that

```go
package main

import (
	foo "gofumpt-ex/foo"
)

func main() {
	foo.Foo("goodbye, world!")
}
```

wasn't being simplified to

```go
package main

import (
	"gofumpt-ex/foo"
)

func main() {
	foo.Foo("goodbye, world!")
}
```

when the package name of "gofumpt-ex/foo" is "foo".

I thought it might be a nice addition, and I wanted to have a bit of a poke around in gofumpt, and so I've this branch.

If this is an unwelcome change, please don't be shy in saying so.