### PR TITLE
remove leading and trailing empty lines in a block

### DIFF
--- a/testdata/script/block-multi.txtar
+++ b/testdata/script/block-multi.txtar
@@ -1,0 +1,195 @@
+exec gofumpt -w foo.go
+cmp foo.go foo.go.golden
+
+exec gofumpt -d foo.go.golden
+! stdout .
+
+-- foo.go --
+package p
+
+func f() {
+	if true {
+
+		println()
+		println()
+
+		println()
+	}
+
+	for true {
+		println()
+		println()
+
+		println()
+
+	}
+
+	{
+
+
+		println(1, 2,
+			3, 4, `foo
+			bar`)
+
+		println(1, 2,
+			3, 4, `foo
+			bar`)
+
+
+
+	}
+
+	{
+
+		// comment directly before
+		println()
+		println()
+
+		println()
+
+		// comment after
+
+	}
+
+	{
+
+		// comment before
+
+		println()
+		println()
+
+		println()
+		// comment directly after
+
+	}
+
+	// For readability; the empty line helps separate the multi-line
+	// condition from the body.
+	if true &&
+		true {
+
+		println()
+		println()
+
+		println()
+	}
+	if true &&
+		true {
+		println()
+		println()
+
+		println()
+
+	} else if true {
+		println()
+		println()
+
+		println()
+	}
+	for true &&
+		true {
+
+		println()
+		println()
+
+		println()
+	}
+	if true &&
+		true {
+
+		// documented multi statement
+		println()
+		println()
+
+		println()
+	}
+}
+-- foo.go.golden --
+package p
+
+func f() {
+	if true {
+		println()
+		println()
+
+		println()
+	}
+
+	for true {
+		println()
+		println()
+
+		println()
+	}
+
+	{
+		println(1, 2,
+			3, 4, `foo
+			bar`)
+
+		println(1, 2,
+			3, 4, `foo
+			bar`)
+	}
+
+	{
+		// comment directly before
+		println()
+		println()
+
+		println()
+
+		// comment after
+	}
+
+	{
+		// comment before
+
+		println()
+		println()
+
+		println()
+		// comment directly after
+	}
+
+	// For readability; the empty line helps separate the multi-line
+	// condition from the body.
+	if true &&
+		true {
+
+		println()
+		println()
+
+		println()
+	}
+	if true &&
+		true {
+		println()
+		println()
+
+		println()
+
+	} else if true {
+		println()
+		println()
+
+		println()
+	}
+	for true &&
+		true {
+
+		println()
+		println()
+
+		println()
+	}
+	if true &&
+		true {
+
+		// documented multi statement
+		println()
+		println()
+
+		println()
+	}
+}

--- a/testdata/script/block-single.txtar
+++ b/testdata/script/block-single.txtar
@@ -53,6 +53,13 @@ func f() {
 
 		println()
 	}
+	if true &&
+		true {
+		println()
+
+	} else if true {
+		println()
+	}
 	for true &&
 		true {
 
@@ -102,6 +109,13 @@ func f() {
 	if true &&
 		true {
 
+		println()
+	}
+	if true &&
+		true {
+		println()
+
+	} else if true {
 		println()
 	}
 	for true &&


### PR DESCRIPTION
This pull request is intended to achieve what was discussed on issue #284 leaving empty trailing lines in a block if it is followed by an else-if statement, otherwise removes it. Also takes over (somewhat) PR #286.

@mvdan please feel free to suggest any change you see suitable. 

close #284 