### PR TITLE
feat: add pre-commit hook for gofumpt formatting

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: gofumpt-format
+  name: Go Code Formatter
+  description: "Automatically formats Go code using gofumpt. Requires Go and gofumpt to be installed."
+  entry: hooks/run-go-fumpt.sh
+  language: script
+  types: [go]
+  files: '\.go$'

--- a/hooks/run-go-fumpt.sh
+++ b/hooks/run-go-fumpt.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! command -v gofumpt &> /dev/null; then
+    echo "Error: gofumpt is not installed or not in your PATH" >&2
+    exit 1
+fi
+
+output=$(gofumpt -l -w "$@")
+
+if [[ -n "$output" ]]; then
+    echo "$output"
+fi
+
+exit 0


### PR DESCRIPTION

### Summary
This pull request introduces a pre-commit hook for formatting Go code using `gofumpt`. The hook automates the process of ensuring Go files adhere to gofumpt's strict formatting guidelines prior to committing, improving code consistency across the project.

### Changes
- Added a `.pre-commit-hooks.yaml` file defining a new hook, `gofumpt-format`, that runs `gofumpt` on all Go files (`.go`).
- The hook uses a custom shell script (`run-go-fumpt.sh`) to execute the `gofumpt` command, ensuring proper error handling and capturing output for the user.
- This setup can be utilized by other projects that want to integrate gofumpt with pre-commit.

### How to Use
1. Add the following to your `.pre-commit-config.yaml` in the target repository:
    ```yaml
    repos:
      - repo: https://github.com/NaturalT314/gofumpt
        rev: <commit-hash-or-tag>
        hooks:
          - id: gofumpt-format
    ```
2. Install pre-commit hooks by running:
    ```bash
    pre-commit install
    ```

This ensures that Go files are automatically formatted when a developer attempts to commit changes.

### Motivation
Automating code formatting ensures all contributions meet consistent style guidelines. Using pre-commit hooks allows teams to catch formatting issues before they are introduced into the codebase, reducing unnecessary review overhead and merge conflicts.

### Testing
Tested the pre-commit hook on local Go projects and confirmed that it formats files correctly and outputs relevant changes before commits.

### Related Issues
None at this time.

Please let me know if any further changes or additions are required. Thank you for considering this contribution!
