### PR TITLE
drop google/go-cmp dependency

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -23,7 +23,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/google/go-cmp/cmp"
 	"golang.org/x/tools/go/ast/astutil"
 
 	"mvdan.cc/gofumpt/internal/govendor/go/format"
@@ -1037,8 +1036,7 @@ func (f *fumpter) shouldMergeAdjacentFields(f1, f2 *ast.Field) bool {
 	}
 
 	// Only merge if the types are equal.
-	opt := cmp.Comparer(func(x, y token.Pos) bool { return true })
-	return cmp.Equal(f1.Type, f2.Type, opt)
+	return reflect.TypeOf(f1.Type) == reflect.TypeOf(f2.Type)
 }
 
 var posType = reflect.TypeOf(token.NoPos)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.22
 
 require (
 	github.com/go-quicktest/qt v1.101.0
-	github.com/google/go-cmp v0.6.0
 	github.com/rogpeppe/go-internal v1.12.0
 	golang.org/x/mod v0.14.0
 	golang.org/x/sync v0.6.0
@@ -13,6 +12,7 @@ require (
 )
 
 require (
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 )


### PR DESCRIPTION
The PR replaces the usage of `github.com/google/go-cmp/cmp` package with `reflect`.