### PR TITLE
fix: directive format regression

### DIFF
--- a/format/format.go
+++ b/format/format.go
@@ -327,14 +327,14 @@ func (f *fumpter) lineEnd(line int) token.Pos {
 var rxCommentDirective = regexp.MustCompile(
 	`^(?:` +
 		`[a-z-]+:[a-z]+` +
-		`|export` +
-		`|extern` +
-		`|line` +
-		`|no(?:inspection|lint)` +
-		`|#nosec` +
-		`|NOSONAR` +
-		`|sys(?:nb)?` +
-		`)\b`)
+		`|export\b` +
+		`|extern\b` +
+		`|line\b` +
+		`|no(?:inspection|lint)\b` +
+		`|#nosec\b` +
+		`|NOSONAR\b` +
+		`|sys(?:nb)?\b` +
+		`)`)
 
 func (f *fumpter) applyPre(c *astutil.Cursor) {
 	f.splitLongLine(c)

--- a/testdata/script/comment-spaced.txtar
+++ b/testdata/script/comment-spaced.txtar
@@ -53,6 +53,16 @@ func c_open(name *byte, mode int, perm int) int
 
 //sysnb	Getpid() (pid int)
 
+//foo:bar_one
+
+//foo:bar-two
+
+//foo:bar01
+
+//foo:barOne
+
+//foo:barTwo
+
 //foo is foo.
 type foo int
 
@@ -123,6 +133,16 @@ func c_open(name *byte, mode int, perm int) int
 //sys   Unlink(path string) (err error)
 
 //sysnb	Getpid() (pid int)
+
+//foo:bar_one
+
+//foo:bar-two
+
+//foo:bar01
+
+//foo:barOne
+
+//foo:barTwo
 
 // foo is foo.
 type foo int


### PR DESCRIPTION
Restores previous directive regexp expectations.

Related to https://github.com/mvdan/gofumpt/pull/327
Fixes https://github.com/mvdan/gofumpt/issues/331