### PR TITLE
Fixes #2: Expose split-long-lines as an extra rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Add a `split_long_lines` extra rule to enable splitting long lines, such as
+function calls, into multiple lines, via `-extra=split_long_lines`. This behavior
+was previously only available via the `GOFUMPT_SPLIT_LONG_LINES=on` environment
+variable, which still works.
+
 Narrow the multi-line function call rule to only place the closing parenthesis
 on its own line when the opening parenthesis ends a line. See #74.
 

--- a/format/format.go
+++ b/format/format.go
@@ -24,7 +24,6 @@ import (
 	"unicode/utf8"
 
 	"golang.org/x/tools/go/ast/astutil"
-
 	"mvdan.cc/gofumpt/internal/govendor/go/format"
 	"mvdan.cc/gofumpt/internal/version"
 )
@@ -83,6 +82,10 @@ type Extra struct {
 
 	// ClotheReturns clothes naked returns in functions with named results.
 	ClotheReturns bool
+
+	// SplitLongLines splits over-long lines, e.g. function calls, into multiple lines.
+	// GOFUMPT_SPLIT_LONG_LINES=on also enables it, for backwards compatibility.
+	SplitLongLines bool
 }
 
 func (e *Extra) String() string {
@@ -93,6 +96,9 @@ func (e *Extra) String() string {
 	if e.ClotheReturns {
 		active = append(active, "clothe_returns")
 	}
+	if e.SplitLongLines {
+		active = append(active, "split_long_lines")
+	}
 	return strings.Join(active, ",")
 }
 
@@ -100,6 +106,7 @@ func (e *Extra) Set(v string) error {
 	if v == "true" {
 		e.GroupParams = true
 		e.ClotheReturns = true
+		e.SplitLongLines = true
 		return nil
 	}
 	*e = Extra{}
@@ -112,6 +119,8 @@ func (e *Extra) Set(v string) error {
 			e.GroupParams = true
 		case "clothe_returns":
 			e.ClotheReturns = true
+		case "split_long_lines":
+			e.SplitLongLines = true
 		default:
 			return fmt.Errorf("unknown rule: %q", s)
 		}
@@ -152,6 +161,11 @@ func File(fset *token.FileSet, file *ast.File, opts Options) {
 
 	if opts.ExtraRules {
 		opts.Extra.Set("true") // enable all the extra rules
+	}
+
+	// GOFUMPT_SPLIT_LONG_LINES=on enables the rule, for backwards compatibility.
+	if os.Getenv("GOFUMPT_SPLIT_LONG_LINES") == "on" {
+		opts.Extra.SplitLongLines = true
 	}
 
 	if opts.LangVersion == "" {
@@ -442,7 +456,12 @@ func commentGroupLooksLikeCode(group *ast.CommentGroup) bool {
 	src := "package p\nfunc _() {\n" + group.Text() + "}\n"
 	// AllErrors avoids the parser's panic/recover bailout on too many errors,
 	// which crashes under tinygo's Wasm target as it lacks recover support.
-	file, err := parser.ParseFile(token.NewFileSet(), "", src, parser.SkipObjectResolution|parser.AllErrors)
+	file, err := parser.ParseFile(
+		token.NewFileSet(),
+		"",
+		src,
+		parser.SkipObjectResolution|parser.AllErrors,
+	)
 	if err != nil {
 		return false
 	}
@@ -772,7 +791,8 @@ func (f *fumpter) applyPre(c *astutil.Cursor) {
 				handleMultiLine(sign.Params)
 				if sign.Results != nil && len(sign.Results.List) > 0 {
 					lastResultLine := f.Line(sign.Results.List[len(sign.Results.List)-1].End())
-					isLastResultOnParamClosingLine := sign.Params != nil && lastResultLine == f.Line(sign.Params.Closing)
+					isLastResultOnParamClosingLine := sign.Params != nil &&
+						lastResultLine == f.Line(sign.Params.Closing)
 					if !isLastResultOnParamClosingLine {
 						handleMultiLine(sign.Results)
 					}
@@ -1021,9 +1041,8 @@ func (f *fumpter) applyPost(c *astutil.Cursor) {
 }
 
 func (f *fumpter) splitLongLine(c *astutil.Cursor) {
-	if os.Getenv("GOFUMPT_SPLIT_LONG_LINES") != "on" {
-		// By default, this feature is turned off.
-		// Turn it on by setting GOFUMPT_SPLIT_LONG_LINES=on.
+	if !f.Extra.SplitLongLines {
+		// Off by default; opt in with -extra=split_long_lines.
 		return
 	}
 	node := c.Node()

--- a/gofmt.go
+++ b/gofmt.go
@@ -134,7 +134,7 @@ func usage() {
 	-e        report all errors (not just the first 10 on different lines)
 	-l        list files whose formatting differs from gofumpt's
 	-w        write result to (source) file instead of stdout
-	-extra    enable extra rules, e.g. -extra=group_params,clothe_returns
+	-extra    enable extra rules, e.g. -extra=group_params,clothe_returns,split_long_lines
 
 	-lang       str    target Go version in the form "go1.X" (default from go.mod)
 	-modpath    str    Go module path containing the source file (default from go.mod)

--- a/testdata/script/diagnose.txtar
+++ b/testdata/script/diagnose.txtar
@@ -82,7 +82,7 @@ package p
 -- foo.go.golden-extra --
 package p
 
-//gofumpt:diagnose version: (devel) (go1.18.29) flags: -lang=go1.16 -modpath=test -extra=group_params,clothe_returns
+//gofumpt:diagnose version: (devel) (go1.18.29) flags: -lang=go1.16 -modpath=test -extra=group_params,clothe_returns,split_long_lines
 -- foo.go.golden-extra-false --
 package p
 

--- a/testdata/script/long-lines.txtar
+++ b/testdata/script/long-lines.txtar
@@ -1,9 +1,28 @@
 cp foo.go foo.go.orig
 
+# By default, long lines are left alone.
 exec gofumpt -w foo.go
 cmp foo.go foo.go.orig
 
+# Another extra rule does not enable line splitting.
+cp foo.go.orig foo.go
+exec gofumpt -extra=group_params -w foo.go
+cmp foo.go foo.go.orig
+
+# The split_long_lines extra rule enables splitting.
+cp foo.go.orig foo.go
+exec gofumpt -extra=split_long_lines -w foo.go
+cmp foo.go foo.go.golden
+
+# The rule enables splitting even when the env var is set to something else.
+env GOFUMPT_SPLIT_LONG_LINES=off
+cp foo.go.orig foo.go
+exec gofumpt -extra=split_long_lines -w foo.go
+cmp foo.go foo.go.golden
+
+# For backwards compatibility, GOFUMPT_SPLIT_LONG_LINES=on still works.
 env GOFUMPT_SPLIT_LONG_LINES=on
+cp foo.go.orig foo.go
 exec gofumpt -w foo.go
 cmp foo.go foo.go.golden
 


### PR DESCRIPTION
### Expose split-long-lines as an extra rule

Fixes #2

The behavior of splitting long lines is currently gated only by the environment variable `GOFUMPT_SPLIT_LONG_LINES` being set to `on`. This makes the behavior dependent on the local environment, which is external global state that is problematic.

For instance, when gofumpt is used as a library, the [gofumpt.Options](https://github.com/mvdan/gofumpt/blob/master/format/format.go#L33) cannot expose this behavior. This means that tools like golangci-lint cannot expose the complete "surface area" of configurable behavior with their configuration file.

When gofumpt is used as a local tool, such as in VSCode, the opacity of the local environment variable makes it difficult to consistently adhere to differing project format requirements. 

Adding this as an `extra` shifts the behavior to being explicit, rather than environmentally implicit.

See also https://github.com/golangci/golangci-lint/discussions/4253#discussioncomment-7838795